### PR TITLE
Fix i18n and control style

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,8 +20,9 @@ include(KDECompilerSettings NO_POLICY_SCOPE)
 
 ################# Find dependencies #################
 
-find_package(Qt5 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS Core Quick Test Gui QuickControls2)
+find_package(Qt5 ${QT_MIN_VERSION} REQUIRED NO_MODULE COMPONENTS Core Quick Test Gui QuickControls2 Svg)
 find_package(KF5Kirigami2 ${KF5_MIN_VERSION})
+find_package(KF5I18n ${KF5_MIN_VERSION})
 
 ################# Enable C++11 features for clang and gcc #################
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,4 +5,4 @@ set(daykountdown_SRCS
 
 qt5_add_resources(RESOURCES resources.qrc)
 add_executable(daykountdown ${daykountdown_SRCS} ${RESOURCES})
-target_link_libraries(daykountdown Qt5::Quick Qt5::Qml Qt5::Gui Qt5::QuickControls2 KF5::Kirigami2)
+target_link_libraries(daykountdown Qt5::Quick Qt5::Qml Qt5::Svg Qt5::Gui Qt5::QuickControls2 KF5::Kirigami2 KF5::I18n)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,16 @@
-#include <QGuiApplication>
+#include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QtQml>
+#include <KLocalizedContext>
+#include <KLocalizedString>
 #include <QUrl>
 #include "backend.h"
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     QGuiApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
-    QGuiApplication app(argc, argv);
+    KLocalizedString::setApplicationDomain("daykountdown");
+    QApplication app(argc, argv);
     QCoreApplication::setOrganizationName("KDE");
     QCoreApplication::setOrganizationDomain("kde.org");
     QCoreApplication::setApplicationName("DayKountdown");
@@ -18,6 +21,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 	engine.rootContext()->setContextProperty("backend", &backend);
 
     engine.load(QUrl(QStringLiteral("qrc:///main.qml")));
+    engine.rootContext()->setContextObject(new KLocalizedContext(&engine));
 
     if (engine.rootObjects().isEmpty()) {
         return -1;


### PR DESCRIPTION
i18n function in QML need KI18n and QApplication is needed for native
controls in a QML application in Plasma.